### PR TITLE
CHAINS-0 crypto/secp256k1: restore //export directives on panic callbacks

### DIFF
--- a/crypto/secp256k1/panic_cb.go
+++ b/crypto/secp256k1/panic_cb.go
@@ -13,10 +13,12 @@ import "unsafe"
 // Callbacks for converting libsecp256k1 internal faults into
 // recoverable Go panics.
 
+//export secp256k1GoPanicIllegal
 func secp256k1GoPanicIllegal(msg *C.char, data unsafe.Pointer) {
 	panic("illegal argument: " + C.GoString(msg))
 }
 
+//export secp256k1GoPanicError
 func secp256k1GoPanicError(msg *C.char, data unsafe.Pointer) {
 	panic("internal error: " + C.GoString(msg))
 }


### PR DESCRIPTION
### Summary

Restores //export CGO directives on secp256k1GoPanicIllegal and secp256k1GoPanicError in crypto/secp256k1/panic_cb.go

### Background

The //export directives were removed to prevent duplicate C symbol definitions (multiple definition of 'secp256k1GoPanicIllegal') when multiple go-ethereum forks were linked into the same Bazel go_library target. This happened because paxosglobal/pax had shared EVM converter packages that imported types from all three forks (go-ethereum, go-ethereum-arbitrum, go-ethereum-optimism), each with its own crypto/secp256k1 CGO package.

### Problem

Without //export, the Go callback functions secp256k1GoPanicIllegal and secp256k1GoPanicError are not exported as C-linkable symbols. However, the CGO preamble in secp256.go still declares them as extern:

  extern void secp256k1GoPanicIllegal(const char* msg, void* data);
  extern void secp256k1GoPanicError(const char* msg, void* data);

  These extern declarations expect the symbols to exist at link time. When this fork is compiled
  standalone in Bazel (not linked alongside upstream go-ethereum which still has //export), the linker
  fails:

  error: undefined reference to 'secp256k1GoPanicError'
  error: undefined reference to 'secp256k1GoPanicIllegal'

  Note: the __attribute__((weak)) annotations added for C function declarations solve a different problem
  (duplicate C-side symbols). They do not help with Go->C exported callbacks which require //export.

### Why this is now safe

  The original duplicate symbol issue has been resolved in paxosglobal/pax by splitting EVM entity
  converter packages into per-chain sub-packages (geth/, optimism/, arbitrum/). Each Bazel go_library
  target now depends on only one go-ethereum fork, so there is no longer any scenario where multiple
  forks' crypto/secp256k1 packages are linked into the same binary.